### PR TITLE
Implementando alterações para rodar dynamodb em produção

### DIFF
--- a/src/main/java/com/fiap/restaurant/external/db/config/DynamoDBConfig.java
+++ b/src/main/java/com/fiap/restaurant/external/db/config/DynamoDBConfig.java
@@ -2,7 +2,9 @@ package com.fiap.restaurant.external.db.config;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
@@ -43,13 +45,18 @@ public class DynamoDBConfig {
     @Bean
     @Primary
     public AmazonDynamoDB amazonDynamoDB() {
-        AWSStaticCredentialsProvider credentialsProvider = new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey));
 
-        AmazonDynamoDBClientBuilder clientBuilder = AmazonDynamoDBClientBuilder.standard();
-        clientBuilder.withCredentials(credentialsProvider);
-        clientBuilder.setEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, awsRegion));
+//        AWSStaticCredentialsProvider credentialsProvider = new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey));
+//
+//        AmazonDynamoDBClientBuilder clientBuilder = AmazonDynamoDBClientBuilder.standard();
+//        clientBuilder.withCredentials(credentialsProvider);
+//        clientBuilder.setEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, awsRegion));
+//
+//        return clientBuilder.build();
 
-        return clientBuilder.build();
+        return AmazonDynamoDBClientBuilder.standard()
+                .withCredentials(new DefaultAWSCredentialsProviderChain())
+                .withRegion(Regions.fromName(awsRegion)).build();
     }
 
     @Bean

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 server:
-  port: 8081
+  port: 8080
 aws:
-  region: sa-east-1
-  dynamodb:
-    endpoint: http://localhost:8000/
-    accessKey: local
-    secretKey: local
+  region: us-east-1
+#  dynamodb:
+#    endpoint: http://localhost:8000/
+#    accessKey: local
+#    secretKey: local


### PR DESCRIPTION
Em prod precisamos utilizar o LabRole (aws academy) e o ecs vai acessar o dynamodb por mais dos panos por conta disso. Obtive essa solução da aqui: https://siecola.com.br/blogs/aws_ddb_java.html
![image](https://github.com/joasgarcia/fiap-pagamento/assets/6011412/5f39f3e6-0944-4754-8a92-6a6d1bd500a9)
